### PR TITLE
removed unworking line which I believe tried to focus on the first re…

### DIFF
--- a/src/app/lib/views/browser/list.js
+++ b/src/app/lib/views/browser/list.js
@@ -286,7 +286,6 @@
             $('.items').attr('tabindex', '1');
             _.defer(function () {
                 self.checkFetchMore();
-                self.$('.items:first').focus();
             });
 
         },


### PR DESCRIPTION
…sult (movie/show) after a search has been made.

this switching of focus interupts with the focus on the search-bar (because it is triggered for every key-down event), which unables to use it

Fixes # .

Changes proposed in this pull request:
- 
- 
- 

I've read the [Contributor License Agreement](/CONTRIBUTING.md#contributor-license-agreement)